### PR TITLE
Configure strict style with Nix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.el]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+changed=$(git diff-tree --no-commit-id --name-only -r HEAD -- '*.el')
+[ -z "$changed" ] && exit 0
+
+warn=false
+for file in $changed; do
+  if [ -f "$file" ]; then
+    # Format the file with Emacs
+    emacs --batch "$file" \
+      --eval '(progn (emacs-lisp-mode) (indent-region (point-min) (point-max)) (whitespace-cleanup) (save-buffer))'
+    # Run checkdoc for warnings
+    msg=$(emacs --batch "$file" -l checkdoc --eval "(checkdoc-file \"$file\" t)" 2>&1)
+    if [ -n "$msg" ]; then
+      warn=true
+      echo "$msg"
+    fi
+  fi
+done
+
+if $warn; then
+  echo "Post-commit style warnings above." >&2
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ bookmarks
 /eln-cache/
 /session.*
 /tree-sitter/
+
+# Nix
+result/
+.direnv/

--- a/README.org
+++ b/README.org
@@ -209,3 +209,8 @@ Selection:
 mu4e-attachments-dir "~/Downloads"
 Comment:
 has been really useful in setting up emails in my Emacs
+* Development
+This repository provides a Nix flake for a reproducible development environment.
+Run `nix develop` to enter a shell with Emacs and Git configured to use
+`.githooks`.  The post-commit hook formats changed Emacs Lisp files and
+reports style issues detected by `checkdoc`.

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Emacs configuration with strict style enforcement";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+
+  outputs = { self, nixpkgs }: {
+    devShells.x86_64-linux.default = let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+    in pkgs.mkShell {
+      packages = with pkgs; [ emacs editorconfig-core-c git ];
+      shellHook = ''
+        export EDITOR=emacs
+        git config core.hooksPath .githooks
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- enforce standard Emacs style via `.editorconfig`
- add a Nix flake for development
- install post-commit hook to autoformat changed Emacs Lisp files and run `checkdoc`
- document the new Nix environment
- ignore Nix build artifacts

## Testing
- `git status --short`
