### PR TITLE
Load use-package extensions before use

### DIFF
--- a/init.el
+++ b/init.el
@@ -69,12 +69,17 @@
       ;; breaks org even when selectively depth set to full
       ;; straight-vc-git-default-clone-depth 1
       )
-(use-package diminish)
 (straight-use-package 'use-package)
+(require 'use-package)
+(require 'use-package-ensure)
+(require 'use-package-delight)
+(require 'use-package-diminish)
 
 (setq use-package-verbose t
       use-package-always-defer nil
       use-package-always-ensure nil)
+
+(use-package diminish)
 
 (require 'auth-source-pass)
 (auth-source-pass-enable)


### PR DESCRIPTION
## Summary
- Load `use-package` via straight before using any `use-package` forms
- Explicitly require `use-package-ensure`, `use-package-delight`, and `use-package-diminish`
- Reorder init to avoid unrecognized keyword errors on Emacs 29

## Testing
- `emacs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b458ef431c8331b881e6f499065008