### PR TITLE
Avoid compiling mu4e

### DIFF
--- a/settings/setup-email.el
+++ b/settings/setup-email.el
@@ -68,6 +68,7 @@ where Mu4e may live in different locations."
 ;; that way mu build put all the mu4e elisp files in my load-path on
 ;; `make install' step
 (use-package mu4e
+  :straight (:type built-in)
   :init (unless hub/mu-binary
           (message "mu binary not found; mu4e may not be available"))
   :custom   (mu4e-mu-binary (or hub/mu-binary "mu"))


### PR DESCRIPTION
## Summary
- Prevent straight.el from rebuilding mu4e by treating it as built-in

## Testing
- `emacs --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b496fb18ac833196135ac93de4bedd