### PR TITLE
Guard treesit config from missing Evil keymaps

### DIFF
--- a/settings/dev/dev-common.el
+++ b/settings/dev/dev-common.el
@@ -162,7 +162,8 @@ _z_oom on node
 (use-package treesit
   :straight (:type built-in)
   :config
-  (evil-normalize-keymaps)
+  (with-eval-after-load 'evil
+    (evil-normalize-keymaps))
   (setq treesit-language-source-alist
         '((bash "https://github.com/tree-sitter/tree-sitter-bash")
           (cmake "https://github.com/uyha/tree-sitter-cmake")


### PR DESCRIPTION
## Summary
- avoid calling `evil-normalize-keymaps` before Evil loads in treesit config

## Testing
- `emacs --version` *(fails: command not found)*
- `sudo apt-get update >/tmp/apt_update.log && tail -n 20 /tmp/apt_update.log` *(fails: 403 Forbidden for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68b49aba57f88331a4f9414084e0ae31