### PR TITLE
Add tmp directory for native compilation

### DIFF
--- a/tmp/.gitkeep
+++ b/tmp/.gitkeep
@@ -1,0 +1,1 @@
+# Ensure tmp directory exists for Emacs temporary files


### PR DESCRIPTION
## Summary
- ensure Emacs has a `tmp` directory for temporary files used during native compilation

## Testing
- `emacs --batch --eval '(setq temporary-file-directory (expand-file-name "tmp/" (getenv "HOME")))' --eval '(make-temp-file "ci-test-")'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68b49d48d9408331840afd517c3086ef